### PR TITLE
Upload of file with more than 64M fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 /vendor
 /composer.lock
 /.vagrant
+/.buildpath
+/.settings
+/.project
 /build

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,4 @@
 /vendor
 /composer.lock
 /.vagrant
-/.buildpath
-/.settings
-/.project
 /build

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -176,6 +176,47 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
 
 
         $factory->createClient('127.0.0.1', 9331)->then(function (Client $client) {
+            $content = str_repeat('abcdefgh', 65535);
+            $request = $client->newRequest(new RequestParameters([
+                'REQUEST_METHOD'  => 'POST',
+                'SCRIPT_FILENAME' => __DIR__ . '/Resources/scripts/echo.php',
+                'CONTENT_LENGTH'  => strlen($content)
+            ]), new StringReader($content));
+
+            $client->sendRequest($request)->then(function (Response $response) use ($client, $content) {
+                $client->close();
+
+                list($header, $body) = explode("\r\n\r\n", $response->getContent()->read());
+
+                list($server) = unserialize($body);
+
+                self::assertEquals(strlen($content), $server['CONTENT_LENGTH']);
+            });
+
+            return $client;
+        });
+
+        $loop->run();
+    }
+
+    /**
+     * @medium
+     */
+    public function testSendSimpleRequestWithPayloadMoreThan64MB()
+    {
+        $this->expectPHPFPMRunning();
+
+        $loop = LoopFactory::create();
+
+        $dnsResolverFactory = new ResolverFactory();
+        $dns = $dnsResolverFactory->createCached('0.0.0.0', $loop);
+
+        $connector = new SocketConnector($loop, $dns);
+
+        $factory = new ClientFactory($loop, $connector);
+
+
+        $factory->createClient('127.0.0.1', 9331)->then(function (Client $client) {
             $content = str_repeat('abcdefgh', 65535 * 100);
             $request = $client->newRequest(new RequestParameters([
                 'REQUEST_METHOD'  => 'POST',

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -159,7 +159,7 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @medium
+     * @large
      */
     public function testSendSimpleRequestWithOversizedPayload()
     {
@@ -176,7 +176,7 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
 
 
         $factory->createClient('127.0.0.1', 9331)->then(function (Client $client) {
-            $content = str_repeat('abcdefgh', 65535);
+            $content = str_repeat('abcdefgh', 65535 * 100);
             $request = $client->newRequest(new RequestParameters([
                 'REQUEST_METHOD'  => 'POST',
                 'SCRIPT_FILENAME' => __DIR__ . '/Resources/scripts/echo.php',

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -159,7 +159,7 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @large
+     * @medium
      */
     public function testSendSimpleRequestWithOversizedPayload()
     {


### PR DESCRIPTION
Hi, we (appserver.io) want to switch to the last version of your FastCGI client implementation and faced the problem, that it seems not to be possible to upload files > 64M. I've raised the content size in the related PHPUnit integration test `testSendSimpleRequestWithOversizedPayload`. After that the the assertion will not be called anymore and the test is marked `risky`.