### PR TITLE
Check if data is resource before closing it

### DIFF
--- a/src/ReaderWriter/StringReader.php
+++ b/src/ReaderWriter/StringReader.php
@@ -45,7 +45,7 @@ class StringReader implements ReaderInterface
 
     private function close()
     {
-        if ($this->data && is_resource($this->data)) {
+        if (is_resource($this->data)) {
             fclose($this->data);
         }
     }

--- a/src/ReaderWriter/StringReader.php
+++ b/src/ReaderWriter/StringReader.php
@@ -45,7 +45,7 @@ class StringReader implements ReaderInterface
 
     private function close()
     {
-        if ($this->data) {
+        if ($this->data && is_resource($this->data)) {
             fclose($this->data);
         }
     }


### PR DESCRIPTION
Removes occasionally triggered PHP Warning "XX is not a valid stream resource in src/ReaderWriter/StringReader.php on line 49"